### PR TITLE
chore: Bump version to 0.1.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**Project Version**: v0.1.2 - Modern CLI architecture with Cobra framework
+**Project Version**: v0.1.3 - Modern CLI architecture with Cobra framework
 
 ## Common Development Commands
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,14 @@ Sitepanda is licensed under the [MIT License](LICENSE).
 
 ## Development Status
 
+### v0.1.3 - Maintenance Release
+
+This release updates the version number and confirms Windows compatibility.
+
+#### Chore
+*   Bump version to 0.1.3
+*   Verified Windows compatibility and release configuration.
+
 ### v0.1.1, 0.1.2 - Bug Fix Release
 
 This release fixes the cancellation behavior and improves output handling.

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -116,8 +116,8 @@ func TestUtilityFunctions(t *testing.T) {
 		if Version == "" {
 			t.Error("Version constant should not be empty")
 		}
-		if Version != "0.1.2" {
-			t.Errorf("Expected version to be '0.1.2', got %q", Version)
+		if Version != "0.1.3" {
+			t.Errorf("Expected version to be '0.1.3', got %q", Version)
 		}
 	})
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -36,7 +36,7 @@ func TestCLIIntegration(t *testing.T) {
 			name:           "Version command",
 			args:           []string{"--version"},
 			expectError:    false,
-			expectedOutput: "0.1.2",
+			expectedOutput: "0.1.3",
 		},
 		{
 			name:           "Init help",

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Version                  = "0.1.2"
+	Version                  = "0.1.3"
 	LightpandaNightlyVersion = "nightly"
 )
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -58,8 +58,8 @@ func TestConstants(t *testing.T) {
 		if Version == "" {
 			t.Error("Version constant should not be empty")
 		}
-		if Version != "0.1.2" {
-			t.Errorf("Expected Version to be '0.1.2', got %q", Version)
+		if Version != "0.1.3" {
+			t.Errorf("Expected Version to be '0.1.3', got %q", Version)
 		}
 	})
 


### PR DESCRIPTION
This pull request increments the project version from 0.1.2 to 0.1.3.

Key changes:
- The main version constant in `utils.go` has been updated.
- Corresponding version checks in `integration_test.go`, `handlers_test.go`, and `utils_test.go` have been updated.
- Applied `go fmt` to the modified files to ensure consistent formatting.

This prepares the project for the v0.1.3 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- チョア
  - アプリケーションのバージョンを 0.1.3 に更新。
  - CLI のバージョン表示と内部バージョン情報を一致させ、Windows 互換性とリリース設定を確認済み。
- テスト
  - バージョンに関する期待値を 0.1.3 に更新し、定数検証テストを同期。
- ドキュメント
  - README と関連ドキュメントに v0.1.3 表記を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->