### PR TITLE
feat(scrape): Add --output-format flag for explicit format control

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**Project Version**: v0.1.3 - Modern CLI architecture with Cobra framework
+**Project Version**: v0.2.0 - Explicit output format control
 
 ## Common Development Commands
 
@@ -103,9 +103,11 @@ The crawler supports graceful shutdown with partial results preservation:
 
 ### Output Formats
 
-- **XML-like text format** (default): Custom structured output with `<page>`, `<title>`, `<url>`, `<content>` tags
-- **JSON format**: Array of page objects (triggered by `.json` file extension in `--outfile`)
-- **Output streams**: Content goes to stdout, logs go to stderr (allows clean shell redirection)
+- **`xml-like`** (default): Custom structured output with `<page>`, `<title>`, `<url>`, `<content>` tags.
+- **`json`**: A single JSON array containing all page objects.
+- **`jsonl`**: Newline-delimited JSON objects, one for each page.
+- The format is now explicitly controlled by the `--output-format` flag in the `scrape` command, not by file extension.
+- **Output streams**: Content goes to stdout, logs go to stderr (allows clean shell redirection).
 
 ## Testing Strategy
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Sitepanda is a command-line interface (CLI) tool written in Go, now with support
 *   If no specific `--content-selector` is provided, Sitepanda pre-filters the HTML by removing `<script>`, `<style>`, `<link>`, `<img>`, and `<video>` tags before attempting content extraction.
 *   Extracts the main "readable" content from each page using `go-readability`.
 *   Converts the extracted HTML content to Markdown.
-*   Outputs the scraped data (title, URL, Markdown content) in an XML-like text format by default.
-*   If the `--outfile` path ends with `.json`, output is in JSON format (an array of page objects).
+*   Outputs the scraped data (title, URL, Markdown content) in multiple formats, controllable via the `--output-format` flag. Supported formats: `xml-like` (default), `json`, and `jsonl`.
 *   Provides options to filter pages by URL patterns (`--match`) and to stop crawling once a specified number of pages have had their content saved (`--limit`).
 *   Allows specifying URL patterns (`--follow-match`) to restrict which discovered links are added to the crawl queue, preventing crawls from expanding into unwanted areas (e.g., other user profiles on a social media site). This is not applicable when using `--url-file`.
 *   Allows specifying a CSS selector (`--content-selector`) to target the main content area of a page for more precise extraction (this bypasses the default pre-filtering).
@@ -88,7 +87,8 @@ These flags work with all commands:
 ### Scrape Command Flags
 
 *   `--url-file <path>`: Path to a file containing a list of URLs to process (one URL per line). If specified, Sitepanda will process each URL from this file individually. This option overrides the `<url>` argument. When `--url-file` is used, the `--follow-match` option is ignored as crawling beyond the provided URLs is not applicable.
-*   `-o, --outfile <path>`: Write the fetched site to a text file. If the path ends with `.json`, the output will be in JSON format. Otherwise, it defaults to an XML-like text format.
+*   `-o, --outfile <path>`: Write the fetched site to a text file. The format is determined by the `--output-format` flag.
+*   `-f, --output-format <format>`: Specifies the output format. Supported values are `xml-like` (default), `json`, and `jsonl`.
 *   `-m, --match <pattern>`: Only extract content from matched pages (glob pattern, can be specified multiple times). Non-matching pages on the same domain are still crawled for links until the `--limit` is reached (this crawling behavior does not apply when `--url-file` is used).
 *   `--follow-match <pattern>`: Only add links matching this glob pattern to the crawl queue (can be specified multiple times). This helps control the scope of the crawl. For example, on a social media site, you might use `--follow-match "/username/**"` to only crawl links related to a specific user. This option is ignored if `--url-file` is used.
 *   `--limit <number>`: Stop processing/fetching new pages once this many pages have had their content successfully saved (0 for no limit). If the process is interrupted (Ctrl+C), partial results will be saved.
@@ -115,10 +115,10 @@ These flags work with all commands:
 
 ## Output Format
 
-Sitepanda supports two output formats:
+Sitepanda supports multiple output formats, controlled by the `--output-format` flag.
 
-1.  **XML-like Text (Default):**
-    If `--outfile` is not specified (output to stdout) or if the `--outfile` path does not end with `.json`.
+1.  **`xml-like` (Default):**
+    This is the default format if `--output-format` is not specified.
 
     ```text
     <page>
@@ -133,8 +133,8 @@ Sitepanda supports two output formats:
     ...
     ```
 
-2.  **JSON:**
-    If the `--outfile` path ends with `.json`. The output is a JSON array of page objects.
+2.  **`json`:**
+    A single JSON array containing all page objects. Useful for standard JSON parsing.
 
     ```json
     [
@@ -145,6 +145,15 @@ Sitepanda supports two output formats:
       },
       ...
     ]
+    ```
+
+3.  **`jsonl` (JSON Lines):**
+    Each page object is a separate, newline-delimited JSON object. This format is useful for streaming results, as each line can be parsed independently.
+
+    ```json
+    {"title":"Page Title 1","url":"http://example.com/page-1","content":"Content for page 1..."}
+    {"title":"Page Title 2","url":"http://example.com/page-2","content":"Content for page 2..."}
+    ...
     ```
 
 ### Shell Redirection
@@ -286,7 +295,10 @@ sitepanda scrape https://example.com
 sitepanda scrape --outfile output.txt https://example.com
 
 # Scrape with JSON output
-sitepanda scrape --outfile output.json https://example.com
+sitepanda scrape --output-format json --outfile output.json https://example.com
+
+# Scrape with JSON Lines output
+sitepanda scrape --output-format jsonl --outfile output.jsonl https://example.com
 ```
 
 ### Advanced Scraping Options
@@ -381,6 +393,15 @@ go test . -run TestProcessHTML      # Test specific functions
 Sitepanda is licensed under the [MIT License](LICENSE).
 
 ## Development Status
+
+### v0.2.0 - Feature Release
+
+This release introduces explicit output format control.
+
+#### ✨ New Features
+*   **Output Format Flag**: Added `--output-format` (or `-f`) flag to `scrape` command to specify output format.
+*   **JSONL Format**: Added support for `jsonl` (JSON Lines) as an output format.
+*   **Explicit Formatting**: The output format is now explicitly controlled by the new flag, not inferred from the output file extension.
 
 ### v0.1.3 - Maintenance Release
 

--- a/cmd/scrape.go
+++ b/cmd/scrape.go
@@ -16,6 +16,7 @@ var (
 	pageLimit           int
 	contentSelector     string
 	waitForNetworkIdle  bool
+	outputFormat        string
 )
 
 // ScrapingHandler is a function that handles the scraping functionality
@@ -51,7 +52,8 @@ func init() {
 	rootCmd.AddCommand(scrapeCmd)
 
 	// Scraping flags
-	scrapeCmd.Flags().StringVarP(&outfile, "outfile", "o", "", "Write the fetched site to a text file. If path ends with .json, output is JSON")
+	scrapeCmd.Flags().StringVarP(&outfile, "outfile", "o", "", "Write the fetched site to a text file.")
+	scrapeCmd.Flags().StringVarP(&outputFormat, "output-format", "f", "xml-like", "Output format (xml-like, json, jsonl)")
 	scrapeCmd.Flags().StringVar(&urlFile, "url-file", "", "Path to a file containing URLs to process (one per line). Overrides <url> argument")
 	scrapeCmd.Flags().StringSliceVarP(&matchPatterns, "match", "m", []string{}, "Only extract content from matched pages (glob pattern, can be specified multiple times)")
 	scrapeCmd.Flags().StringSliceVar(&followMatchPatterns, "follow-match", []string{}, "Only add links matching this glob pattern to the crawl queue (can be specified multiple times)")
@@ -69,3 +71,4 @@ func GetFollowMatchPatterns() []string { return followMatchPatterns }
 func GetPageLimit() int                { return pageLimit }
 func GetContentSelector() string       { return contentSelector }
 func GetWaitForNetworkIdle() bool      { return waitForNetworkIdle }
+func GetOutputFormat() string          { return outputFormat }

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -116,8 +116,8 @@ func TestUtilityFunctions(t *testing.T) {
 		if Version == "" {
 			t.Error("Version constant should not be empty")
 		}
-		if Version != "0.1.3" {
-			t.Errorf("Expected version to be '0.1.3', got %q", Version)
+		if Version != "0.2.0" {
+			t.Errorf("Expected version to be '0.2.0', got %q", Version)
 		}
 	})
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -36,7 +36,7 @@ func TestCLIIntegration(t *testing.T) {
 			name:           "Version command",
 			args:           []string{"--version"},
 			expectError:    false,
-			expectedOutput: "0.1.3",
+			expectedOutput: "0.2.0",
 		},
 		{
 			name:           "Init help",
@@ -194,6 +194,47 @@ func TestEnvironmentVariables(t *testing.T) {
 			// The output should contain help text since we're using --help
 			if !strings.Contains(string(output), "Download and install") {
 				t.Errorf("Expected help output, got %q", string(output))
+			}
+		})
+	}
+}
+
+func TestScrapeOutputFormatFlag(t *testing.T) {
+	binaryPath := filepath.Join(os.TempDir(), "sitepanda-test")
+	if err := exec.Command("go", "build", "-o", binaryPath, ".").Run(); err != nil {
+		t.Fatalf("Failed to build binary for testing: %v", err)
+	}
+	defer os.Remove(binaryPath)
+
+	tests := []struct {
+		name        string
+		args        []string
+		expectedLog string
+	}{
+		{
+			name:        "Default format",
+			args:        []string{"scrape", "http://example.com"},
+			expectedLog: "Output Format: xml-like",
+		},
+		{
+			name:        "JSONL format flag",
+			args:        []string{"scrape", "--output-format", "jsonl", "http://example.com"},
+			expectedLog: "Output Format: jsonl",
+		},
+		{
+			name:        "JSON format flag short",
+			args:        []string{"scrape", "-f", "json", "http://example.com"},
+			expectedLog: "Output Format: json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command(binaryPath, tt.args...)
+			output, _ := cmd.CombinedOutput() // We ignore the error because the command is expected to fail
+
+			if !strings.Contains(string(output), tt.expectedLog) {
+				t.Errorf("Expected log to contain %q, got %q", tt.expectedLog, string(output))
 			}
 		})
 	}

--- a/scraping_handler.go
+++ b/scraping_handler.go
@@ -67,6 +67,9 @@ func HandleScraping(args []string) {
 		os.Exit(1)
 	}
 
+	// Early log for testing
+	logger.Printf("Output Format: %s", cmd.GetOutputFormat())
+
 	logger.Printf("Sitepanda v%s starting with browser: %s", Version, browserName)
 
 	playwrightDriverDir, err := GetAppSubdirectory("playwright_driver")
@@ -122,6 +125,7 @@ func HandleScraping(args []string) {
 	pageLimit := cmd.GetPageLimit()
 	contentSelector := cmd.GetContentSelector()
 	waitForNetworkIdle := cmd.GetWaitForNetworkIdle()
+	outputFormat := cmd.GetOutputFormat()
 
 	logger.Printf("Configuration:")
 	logger.Printf("  Start URL (or first from list): %s", startURLForCrawler)
@@ -138,6 +142,7 @@ func HandleScraping(args []string) {
 		logger.Printf("  Chromium managed by Playwright in: %s", playwrightDriverDir)
 	}
 	logger.Printf("  Outfile: %s", outfile)
+	logger.Printf("  Output Format: %s", outputFormat)
 	logger.Printf("  Match Patterns (for content saving): %v", matchPatterns)
 	if isURLListMode {
 		logger.Printf("  Follow Match Patterns (for crawling): %v (ignored in URL list mode)", followMatchPatterns)
@@ -153,9 +158,9 @@ func HandleScraping(args []string) {
 	var crawlerErr error
 
 	if browserName == "lightpanda" {
-		crawler, crawlerErr = NewCrawlerForLightpanda(startURLForCrawler, targetURLsForCrawler, isURLListMode, wsURL, pwInstance, pageLimit, matchPatterns, followMatchPatterns, contentSelector, outfile, cmd.GetSilent(), waitForNetworkIdle)
+		crawler, crawlerErr = NewCrawlerForLightpanda(startURLForCrawler, targetURLsForCrawler, isURLListMode, wsURL, pwInstance, pageLimit, matchPatterns, followMatchPatterns, contentSelector, outfile, cmd.GetSilent(), waitForNetworkIdle, outputFormat)
 	} else if browserName == "chromium" {
-		crawler, crawlerErr = NewCrawlerForPlaywrightBrowser(startURLForCrawler, targetURLsForCrawler, isURLListMode, pwBrowser, pageLimit, matchPatterns, followMatchPatterns, contentSelector, outfile, cmd.GetSilent(), waitForNetworkIdle)
+		crawler, crawlerErr = NewCrawlerForPlaywrightBrowser(startURLForCrawler, targetURLsForCrawler, isURLListMode, pwBrowser, pageLimit, matchPatterns, followMatchPatterns, contentSelector, outfile, cmd.GetSilent(), waitForNetworkIdle, outputFormat)
 	} else {
 		logger.Fatalf("Unsupported browser for crawler creation: %s", browserName)
 	}

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	Version                  = "0.1.3"
+	Version                  = "0.2.0"
 	LightpandaNightlyVersion = "nightly"
 )
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -58,8 +58,8 @@ func TestConstants(t *testing.T) {
 		if Version == "" {
 			t.Error("Version constant should not be empty")
 		}
-		if Version != "0.1.3" {
-			t.Errorf("Expected Version to be '0.1.3', got %q", Version)
+		if Version != "0.2.0" {
+			t.Errorf("Expected Version to be '0.2.0', got %q", Version)
 		}
 	})
 


### PR DESCRIPTION
This change introduces a new `--output-format` flag (short: `-f`) to the `scrape` subcommand, allowing users to explicitly specify the output format.

Previously, the output format was implicitly determined by the file extension of the output path (e.g., `.json`). This change makes the process explicit and adds support for a new `jsonl` format.

Changes include:
- A new `--output-format` flag with allowed values: `xml-like`, `json`, `jsonl`. The default is `xml-like`.
- The output logic now uses the value from this flag instead of checking the output file's extension.
- A new `formatResultsAsJSONL` function to produce JSON Lines output.
- The application version has been bumped to `0.2.0`.
- Unit tests for the new `jsonl` formatter and integration tests for the new flag have been added.
- Fixed hardcoded version numbers in existing tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - scrapeコマンドに--output-format/-fを追加。xml-like（既定）/json/jsonlを選択可能、選択した形式で出力・保存しログに出力形式を表示。
- テスト
  - jsonl出力の単体テストを追加。CLI統合テストで出力フォーマット指定を検証。
- ドキュメント
  - READMEとCLAUDE.mdで出力フォーマット仕様、使用例、jsonlサンプルを更新。
- 雑務
  - バージョンを0.2.0に更新。ヘルプ文言を調整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->